### PR TITLE
Added UR10 mount as a husky accessory

### DIFF
--- a/husky_description/urdf/accessories/ur10_mount.urdf.xacro
+++ b/husky_description/urdf/accessories/ur10_mount.urdf.xacro
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:macro name="ur10_mount" params="prefix parent_link use_namespace robot_namespace">
+    <xacro:include filename="$(find craftsman_robots)/urdf/ur10/ur10_robot_attachment.urdf.xacro" />
+
+    <xacro:ur10_robot_attachment prefix="ur10_" joint_limited="false" transmission_hw_interface="hardware_interface/PositionJointInterface"/>
+
+    <joint name="ur10_joint" type="fixed">
+      <parent link="${parent_link}" />
+      <child link = "${prefix}base_link" />
+    </joint>
+  </xacro:macro>
+</robot>

--- a/husky_description/urdf/husky.urdf.xacro
+++ b/husky_description/urdf/husky.urdf.xacro
@@ -42,6 +42,11 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:arg name="realsense_rpy" default="$(optenv HUSKY_REALSENSE_RPY 0 0 0)" />
   <xacro:arg name="realsense_mount" default="$(optenv HUSKY_REALSENSE_MOUNT_FRAME sensor_arch_mount_link)" />
 
+  <xacro:arg name="ur10_enabled" default="$(optenv HUSKY_UR10_ENABLED 0)" />
+  <xacro:arg name="ur10_xyz" default="$(optenv HUSKY_UR10_XYZ -0.105 0.0 0)" />
+  <xacro:arg name="ur10_rpy" default="$(optenv HUSKY_UR10_RPY 0 0 3.1415927)" />
+  <xacro:arg name="ur10_mount" default="$(optenv HUSKY_UR10_MOUNT_FRAME top_plate_front_link)" />
+
   <xacro:property name="husky_front_bumper_extend" value="$(optenv HUSKY_FRONT_BUMPER_EXTEND 0)" />
   <xacro:property name="husky_rear_bumper_extend" value="$(optenv HUSKY_REAR_BUMPER_EXTEND 0)" />
 
@@ -187,7 +192,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
   <xacro:property name="sensorbar_needed_lidar"     value="$(arg laser_3d_enabled)" />
   <xacro:if value="${sensorbar_needed_realsense or sensorbar_user_enabled or sensorbar_needed_lidar}">
     <xacro:sensor_arch prefix="" parent="top_plate_link" size="$(arg sensor_arch_height)">
-        <origin xyz="$(optenv HUSKY_SENSOR_ARCH_OFFSET 0 0 0)" rpy="$(optenv HUSKY_SENSOR_ARCH_RPY 0 0 0)"/>
+        <origin xyz="$(optenv HUSKY_SENSOR_ARCH_OFFSET -0.3 0 0)" rpy="$(optenv HUSKY_SENSOR_ARCH_RPY 0 0 0)"/>
       </xacro:sensor_arch>
   </xacro:if>
 
@@ -209,6 +214,18 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
     <xacro:vlp16_mount prefix="" parent_link="sensor_arch_mount_link" topic="$(optenv HUSKY_LASER_3D_TOPIC points)">
       <origin xyz="$(arg laser_3d_xyz)" rpy="$(arg laser_3d_rpy)" />
     </xacro:vlp16_mount>
+  </xacro:if>
+
+  <xacro:if value="$(arg ur10_enabled)">
+    <xacro:include filename="$(find husky_description)/urdf/accessories/ur10_mount.urdf.xacro"/>
+
+    <link name="ur10_mountpoint"/>
+    <joint name="ur10_mountpoint_joint" type="fixed">
+      <origin xyz="$(arg ur10_xyz)" rpy="$(arg ur10_rpy)" />
+      <parent link="$(arg ur10_mount)"/>
+      <child link="ur10_mountpoint" />
+    </joint>
+    <xacro:ur10_mount prefix="ur10_" use_namespace="$(arg use_namespace)" robot_namespace="$(arg robot_namespace)" parent_link="ur10_mountpoint"/>
   </xacro:if>
 
   <gazebo>


### PR DESCRIPTION
Repos to have in sync:
1.  Husky
2. craftsman_application_tools
3. lunar_assembly_tools
--------------------------

It can be tested by running:
`roslaunch lunar_assembly_demo husky_ur10.launch`

This [page](https://traclabs.atlassian.net/wiki/spaces/CAR/pages/2869035009/Adding+a+UR10+arm+to+any+mobile+robot) also shows how to repeat this for another mobile robot

--------------------------
Changes:
- Added a ur10_mount.urdf.xacro (Note: it might be worth moving this to craftsman_robots since it is not husky specific)
- Add ur10 parameters to the husky.urdf.xacro (Note: it might also be worth removing it from here and adding it as a urdf_extra)
